### PR TITLE
Wip applicative

### DIFF
--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -7,6 +7,7 @@ module Algebra.Applicative(Applicative(..), ApplicativeLaws(..)) where
 import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
 import Algebra.Base(Functor(..), Applicative(..), ApplicativeLaws(..))
 import Algebra.Functor
+import Data.Typeable (Proxy)
 
 instance Applicative [] where
   pure a = [a]
@@ -37,6 +38,6 @@ instance ApplicativeLaws where
   applyComp pg pf fa = pure (.) |*| pg |*| pf |*| fa == pg |*| (pf |*| fa)
   applyHomo          = homomorphism
 
-homomorphism :: forall a b proxy f.(Eq (f b), Applicative f) => proxy f -> (a -> b) -> a -> Bool
+homomorphism :: forall a b f.(Eq (f b), Applicative f) => Proxy f -> (a -> b) -> a -> Bool
 homomorphism _ g x = (pure (g x) :: f b) == (pure g |*| (pure x :: f a))
 

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -1,0 +1,18 @@
+module Algebra.Applicative(Applicative(..), ApplicativeLaws(..)) where
+
+import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
+import Algebra.Base(Functor(..), Applicative(..), ApplicativeLaws(..))
+import Algebra.Functor
+
+instance Applicative [] where
+  pure a = [a]
+  apply fs xs = foldl (\bs f -> bs ++ fmap f xs) [] fs
+  {-# INLINABLE pure #-}
+  {-# INLINABLE apply #-}
+
+instance Applicative Maybe where
+  pure = Just
+  apply (Just f) (Just a) = Just (f a)
+  apply _ _               = Nothing
+  {-# INLINE pure #-}
+  {-# INLINABLE apply #-}

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -23,10 +23,11 @@ instance Applicative Maybe where
 
 (pure f) |*| x = fmap f x
 pure id |*| v = v
-pure (.) |*| u |*| v |*| w = u <*> (v <*> w)
+pure (.) |*| u |*| v |*| w = u |*| (v |*| w)
 pure f |*| pure x = pure (f x)
 u |*| pure y = pure ($ y) |*| u
 |-}
 instance ApplicativeLaws where
   applyMap f fa =  pure f |*| fa == fmap f fa
   applyId fa = pure id |*| fa == fa
+  applyLifted pf y = pf |*| pure y == pure ($ y) |*| pf

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE InstanceSigs #-}
 
 module Algebra.Applicative(Applicative(..), ApplicativeLaws(..)) where
 
@@ -34,4 +33,4 @@ instance ApplicativeLaws where
   applyId fa         = pure id |*| fa == fa
   applyInter pf y    = pf |*| pure y  == pure ($ y) |*| pf
   applyComp pg pf fa = pure (.) |*| pg |*| pf |*| fa == pg |*| (pf |*| fa)
---  applyHomo f a = pure f |*| pure a == pure (f a)
+  applyHomo p f a    = p f |*| p a == p (f a)

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE InstanceSigs #-}
+
 module Algebra.Applicative(Applicative(..), ApplicativeLaws(..)) where
 
 import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
@@ -28,7 +30,8 @@ pure f |*| pure x = pure (f x)
 u |*| pure y = pure ($ y) |*| u
 |-}
 instance ApplicativeLaws where
-  applyMap f fa =  pure f |*| fa == fmap f fa
-  applyId fa = pure id |*| fa == fa
-  applyLifted pf y = pf |*| pure y == pure ($ y) |*| pf
-  applyComp pg pf fa  = pure (.) |*| pg |*| pf |*| fa == pg |*| (pf |*| fa)
+  applyMap f fa      = pure f  |*| fa == fmap f fa
+  applyId fa         = pure id |*| fa == fa
+  applyInter pf y    = pf |*| pure y  == pure ($ y) |*| pf
+  applyComp pg pf fa = pure (.) |*| pg |*| pf |*| fa == pg |*| (pf |*| fa)
+--  applyHomo f a = pure f |*| pure a == pure (f a)

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Algebra.Applicative(Applicative(..), ApplicativeLaws(..)) where
 
 import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
@@ -16,3 +17,16 @@ instance Applicative Maybe where
   apply _ _               = Nothing
   {-# INLINE pure #-}
   {-# INLINABLE apply #-}
+
+{-|
+  The laws are
+
+(pure f) |*| x = fmap f x
+pure id |*| v = v
+pure (.) |*| u |*| v |*| w = u <*> (v <*> w)
+pure f |*| pure x = pure (f x)
+u |*| pure y = pure ($ y) |*| u
+|-}
+instance ApplicativeLaws where
+  applyMap f fa =  pure f |*| fa == fmap f fa
+  applyId fa = pure id |*| fa == fa

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 
 module Algebra.Applicative(Applicative(..), ApplicativeLaws(..)) where
 
@@ -33,4 +35,8 @@ instance ApplicativeLaws where
   applyId fa         = pure id |*| fa == fa
   applyInter pf y    = pf |*| pure y  == pure ($ y) |*| pf
   applyComp pg pf fa = pure (.) |*| pg |*| pf |*| fa == pg |*| (pf |*| fa)
-  applyHomo p f a    = p f |*| p a == p (f a)
+  applyHomo          = homomorphism
+
+homomorphism :: forall a b proxy f.(Eq (f b), Applicative f) => proxy f -> (a -> b) -> a -> Bool
+homomorphism _ g x = (pure (g x) :: f b) == (pure g |*| (pure x :: f a))
+

--- a/src/Algebra/Applicative.hs
+++ b/src/Algebra/Applicative.hs
@@ -31,3 +31,4 @@ instance ApplicativeLaws where
   applyMap f fa =  pure f |*| fa == fmap f fa
   applyId fa = pure id |*| fa == fa
   applyLifted pf y = pf |*| pure y == pure ($ y) |*| pf
+  applyComp pg pf fa  = pure (.) |*| pg |*| pf |*| fa == pg |*| (pf |*| fa)

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -87,7 +87,7 @@ class (Functor f) => Applicative f where
   {-# MINIMAL pure, apply #-}
 
 class ApplicativeLaws where
-  applyMap :: (Eq (f a), Applicative f) => (a -> b) -> f a -> Bool
+  applyMap :: (Eq (f b), Applicative f) => (a -> b) -> f a -> Bool
   applyId :: (Eq (f a), Applicative f) => f a -> Bool
   {-# MINIMAL applyMap, applyId #-}
 {-|

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ExplicitForAll #-}
 
 module Algebra.Base where
 
@@ -83,8 +82,8 @@ class (Functor f) => Applicative f where
   pure :: a -> f a
   apply :: f (a -> b) -> f a -> f b
   (|*|) :: f (a -> b) -> f a -> f b
-  (|$|) :: (a -> b) -> f a -> f b
   (|*|) = apply
+  (|$|) :: (a -> b) -> f a -> f b
   (|$|) = fmap
   {-# INLINE (|*|) #-}
   {-# INLINE (|$|) #-}
@@ -94,7 +93,7 @@ class (Functor f) => Applicative f where
 class ApplicativeLaws  where
   applyMap :: (Eq (f b), (Applicative f)) => (a -> b) -> f a -> Bool
   applyId :: (Eq (f a), (Applicative f)) => f a -> Bool
-  applyHomo :: forall a b f.(Eq (f b), Applicative f) => Proxy f -> (a -> b) -> a -> Bool
+  applyHomo :: (Eq (f b), Applicative f) => Proxy f -> (a -> b) -> a -> Bool
   applyInter :: (Eq (f b), (Applicative f)) => f (a -> b) -> a -> Bool
   applyComp :: (Eq (f c), (Applicative f)) => f (b -> c) -> f (a -> b) -> f a -> Bool
   {-# MINIMAL applyMap, applyId, applyInter, applyComp, applyHomo #-}

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ExplicitForAll #-}
 
 module Algebra.Base where
 
@@ -94,14 +94,12 @@ class (Functor f) => Applicative f where
 class ApplicativeLaws  where
   applyMap :: (Eq (f b), (Applicative f)) => (a -> b) -> f a -> Bool
   applyId :: (Eq (f a), (Applicative f)) => f a -> Bool
-  applyHomo :: (Eq (f b), (Applicative f)) => (forall x. x -> f x) -> (a -> b) -> a ->  Bool
+  applyHomo :: forall a b proxy f.(Eq (f b), Applicative f) => proxy f -> (a -> b) -> a -> Bool
   applyInter :: (Eq (f b), (Applicative f)) => f (a -> b) -> a -> Bool
   applyComp :: (Eq (f c), (Applicative f)) => f (b -> c) -> f (a -> b) -> f a -> Bool
   {-# MINIMAL applyMap, applyId, applyInter, applyComp, applyHomo #-}
-{-|
-  A Monad algebra describes the propagation of an effect thru the application of
-  a Kleisli construct a -> m b
 
+{-|
   A Monad is an Algebra built on a Functor algebra equiped with a flatten function.
   The complete description of the effect propagation is being provided by a
   bind function

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -91,7 +91,8 @@ class ApplicativeLaws where
   applyId :: (Eq (f a), Applicative f) => f a -> Bool
 --  conserveLift :: (Eq b, Applicative f) => (a -> f a) -> (a -> b) -> a ->  Bool
   applyLifted :: (Eq (f b), Applicative f) => f (a -> b) -> a -> Bool
-  {-# MINIMAL applyMap, applyId, applyLifted #-}
+  applyComp :: (Eq (f c), Applicative f) => f (b -> c) -> f (a -> b) -> f a -> Bool
+  {-# MINIMAL applyMap, applyId, applyLifted, applyComp #-}
 {-|
   A Monad algebra describes the propagation of an effect thru the application of
   a Kleisli construct a -> m b

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -4,6 +4,9 @@
 module Algebra.Base where
 
 import Prelude hiding (Semigroup, Monoid, Functor, Applicative, Monad, fmap, flatten)
+import Data.Typeable (Proxy)
+import Data.Proxy (KProxy)
+import Data.Kind (Type)
 
 {-|
  given a set S
@@ -30,7 +33,7 @@ class SemiGroupLaws where
 > ∃! e ∈ S , ∀ a ∈ S,  a ⊗ e = e ⊗ a = a
 
 The structure (S, ⊗, e) is a monoid.
-
+, Applicative f
   A Monoid is a 'SemiGroup'
 -}
 class (SemiGroup a) => Monoid a where
@@ -86,13 +89,13 @@ class (Functor f) => Applicative f where
   {-# INLINE (|$|) #-}
   {-# MINIMAL pure, apply #-}
 
-class ApplicativeLaws where
-  applyMap :: (Eq (f b), Applicative f) => (a -> b) -> f a -> Bool
-  applyId :: (Eq (f a), Applicative f) => f a -> Bool
---  conserveLift :: (Eq b, Applicative f) => (a -> f a) -> (a -> b) -> a ->  Bool
-  applyLifted :: (Eq (f b), Applicative f) => f (a -> b) -> a -> Bool
-  applyComp :: (Eq (f c), Applicative f) => f (b -> c) -> f (a -> b) -> f a -> Bool
-  {-# MINIMAL applyMap, applyId, applyLifted, applyComp #-}
+class ApplicativeLaws  where
+  applyMap :: (Eq (f b), (Applicative f)) => (a -> b) -> f a -> Bool
+  applyId :: (Eq (f a), (Applicative f)) => f a -> Bool
+--  applyHomo :: (a -> b) -> a ->  Bool
+  applyInter :: (Eq (f b), (Applicative f)) => f (a -> b) -> a -> Bool
+  applyComp :: (Eq (f c), (Applicative f)) => f (b -> c) -> f (a -> b) -> f a -> Bool
+  {-# MINIMAL applyMap, applyId, applyInter, applyComp #-}
 {-|
   A Monad algebra describes the propagation of an effect thru the application of
   a Kleisli construct a -> m b

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Rank2Types #-}
 
 module Algebra.Base where
 
-import Prelude hiding (Semigroup, Monoid, Functor, Applicative, Monad, fmap, flatten)
+import Prelude hiding (Semigroup, Monoid, Functor, Applicative, Monad, fmap, flatten, pure)
 import Data.Typeable (Proxy)
 import Data.Proxy (KProxy)
 import Data.Kind (Type)
@@ -89,13 +90,14 @@ class (Functor f) => Applicative f where
   {-# INLINE (|$|) #-}
   {-# MINIMAL pure, apply #-}
 
+
 class ApplicativeLaws  where
   applyMap :: (Eq (f b), (Applicative f)) => (a -> b) -> f a -> Bool
   applyId :: (Eq (f a), (Applicative f)) => f a -> Bool
---  applyHomo :: (a -> b) -> a ->  Bool
+  applyHomo :: (Eq (f b), (Applicative f)) => (forall x. x -> f x) -> (a -> b) -> a ->  Bool
   applyInter :: (Eq (f b), (Applicative f)) => f (a -> b) -> a -> Bool
   applyComp :: (Eq (f c), (Applicative f)) => f (b -> c) -> f (a -> b) -> f a -> Bool
-  {-# MINIMAL applyMap, applyId, applyInter, applyComp #-}
+  {-# MINIMAL applyMap, applyId, applyInter, applyComp, applyHomo #-}
 {-|
   A Monad algebra describes the propagation of an effect thru the application of
   a Kleisli construct a -> m b

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -94,7 +94,7 @@ class (Functor f) => Applicative f where
 class ApplicativeLaws  where
   applyMap :: (Eq (f b), (Applicative f)) => (a -> b) -> f a -> Bool
   applyId :: (Eq (f a), (Applicative f)) => f a -> Bool
-  applyHomo :: forall a b proxy f.(Eq (f b), Applicative f) => proxy f -> (a -> b) -> a -> Bool
+  applyHomo :: forall a b f.(Eq (f b), Applicative f) => Proxy f -> (a -> b) -> a -> Bool
   applyInter :: (Eq (f b), (Applicative f)) => f (a -> b) -> a -> Bool
   applyComp :: (Eq (f c), (Applicative f)) => f (b -> c) -> f (a -> b) -> f a -> Bool
   {-# MINIMAL applyMap, applyId, applyInter, applyComp, applyHomo #-}

--- a/src/Algebra/Base.hs
+++ b/src/Algebra/Base.hs
@@ -89,7 +89,9 @@ class (Functor f) => Applicative f where
 class ApplicativeLaws where
   applyMap :: (Eq (f b), Applicative f) => (a -> b) -> f a -> Bool
   applyId :: (Eq (f a), Applicative f) => f a -> Bool
-  {-# MINIMAL applyMap, applyId #-}
+--  conserveLift :: (Eq b, Applicative f) => (a -> f a) -> (a -> b) -> a ->  Bool
+  applyLifted :: (Eq (f b), Applicative f) => f (a -> b) -> a -> Bool
+  {-# MINIMAL applyMap, applyId, applyLifted #-}
 {-|
   A Monad algebra describes the propagation of an effect thru the application of
   a Kleisli construct a -> m b

--- a/src/Algebra/Monad.hs
+++ b/src/Algebra/Monad.hs
@@ -2,21 +2,18 @@
 
 module Algebra.Monad(Monad(..), MonadLaws(..)) where
 
-import Prelude hiding(Monad(..), Functor(..), pure)
-import Algebra.Base(Functor(..), Monad(..), MonadLaws(..))
+import Prelude hiding(Monad(..), Functor(..), Applicative(..), pure)
+import Algebra.Base(Functor(..), Applicative(..), Monad(..), MonadLaws(..))
 import Algebra.Functor
+import Algebra.Applicative
 
 instance Monad [] where
-  pure a    = [a]
   flatten   = foldr (++) []
-  {-# INLINABLE pure #-}
   {-# INLINABLE flatten #-}
 
 instance Monad Maybe where
-  pure = Just
   flatten (Just (Just a)) = Just a
   flatten _               = Nothing
-  {-# INLINE pure #-}
   {-# INLINABLE flatten #-}
 
 instance MonadLaws where

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -1,0 +1,35 @@
+module Algebra.ApplicativeSpec(spec) where
+
+import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
+import Algebra.Applicative(Applicative(..), ApplicativeLaws(..))
+import Algebra.Base(Applicative(..), ApplicativeLaws(..))
+import Algebra.Functor
+import Test.Hspec
+import Test.QuickCheck
+
+spec :: Spec
+spec = do
+  spec_applyMap
+  spec_applyId
+
+spec_applyMap :: Spec
+spec_applyMap =
+  describe "apply Map" $ do
+    it "should verify conservation of fmap for lists" $
+      property (let s :: Int -> String
+                    s = show
+                in applyMap s :: [Int] -> Bool)
+    it "should verify conservation of  fmap for Maybe" $
+      property ( let s :: Int -> String
+                     s = show
+                 in applyMap s :: Maybe Int -> Bool)
+
+
+spec_applyId :: Spec
+spec_applyId =
+  describe "apply Map" $ do
+    it "should conserve id for lists" $
+      property (applyId::[Int] -> Bool)
+    it "should conserve id for Maybe " $
+      property (applyId::Maybe Int -> Bool)
+

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -41,11 +41,11 @@ spec_applyLifted =
     it "should be applied to list" $
       property (let ps :: [Int -> String]
                     ps = pure show
-                 in applyLifted ps)
+                 in applyInter ps)
     it "should be applied to Maybe" $
       property (let ps :: Maybe (Int -> String)
                     ps = pure show
-                 in applyLifted ps)
+                 in applyInter ps)
 
 spec_applyComp :: Spec
 spec_applyComp =

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE Rank2Types #-}
-
 module Algebra.ApplicativeSpec(spec) where
 
 import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
 import Algebra.Applicative(Applicative(..), ApplicativeLaws(..))
 import Algebra.Base(Applicative(..), ApplicativeLaws(..))
 import Algebra.Functor
+import Data.Proxy
 import Test.Hspec
 import Test.QuickCheck
 
@@ -69,10 +68,6 @@ spec_Composition =
 spec_Homorphism :: Spec
 spec_Homorphism = describe "apply" $ do
   it "should be homomorphic for Lists" $
-    property (let p :: x -> [x]
-                  p = pure
-              in applyHomo p (show:: Int -> String))
+    property (applyHomo (Proxy :: Proxy Maybe) (show:: Int -> String))
   it "should be homomorphic for Maybe" $
-    property (let p :: x -> Maybe x
-                  p = pure
-              in applyHomo p (show:: Int -> String))
+    property (applyHomo (Proxy :: Proxy []) (show:: Int -> String))

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Rank2Types #-}
+
 module Algebra.ApplicativeSpec(spec) where
 
 import Prelude hiding(Applicative(..), Functor(..), pure, (<*>), (<$>), fmap)
@@ -10,9 +12,10 @@ import Test.QuickCheck
 spec :: Spec
 spec = do
   spec_applyMap
-  spec_applyId
-  spec_applyLifted
-  spec_applyComp
+  spec_Identity
+  spec_Interchange
+  spec_Composition
+  spec_Homorphism
 
 spec_applyMap :: Spec
 spec_applyMap =
@@ -27,16 +30,16 @@ spec_applyMap =
                  in applyMap s :: Maybe Int -> Bool)
 
 
-spec_applyId :: Spec
-spec_applyId =
+spec_Identity :: Spec
+spec_Identity =
   describe "apply Map" $ do
     it "should conserve id for lists" $
       property (applyId::[Int] -> Bool)
     it "should conserve id for Maybe " $
       property (applyId::Maybe Int -> Bool)
 
-spec_applyLifted :: Spec
-spec_applyLifted =
+spec_Interchange :: Spec
+spec_Interchange =
   describe "lifted function" $ do
     it "should be applied to list" $
       property (let ps :: [Int -> String]
@@ -47,8 +50,8 @@ spec_applyLifted =
                     ps = pure show
                  in applyInter ps)
 
-spec_applyComp :: Spec
-spec_applyComp =
+spec_Composition :: Spec
+spec_Composition =
   describe "apply composition" $ do
     it "should be lifted for lists" $
       property (let f :: [Double -> Double]
@@ -62,3 +65,14 @@ spec_applyComp =
                     g :: Maybe (Double -> String)
                     g = Just show
                  in applyComp g f)
+
+spec_Homorphism :: Spec
+spec_Homorphism = describe "apply" $ do
+  it "should be homomorphic for Lists" $
+    property (let p :: x -> [x]
+                  p = pure
+              in applyHomo p (show:: Int -> String))
+  it "should be homomorphic for Maybe" $
+    property (let p :: x -> Maybe x
+                  p = pure
+              in applyHomo p (show:: Int -> String))

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -67,7 +67,7 @@ spec_Composition =
 
 spec_Homorphism :: Spec
 spec_Homorphism = describe "apply" $ do
-  it "should be homomorphic for Lists" $
-    property (applyHomo (Proxy :: Proxy Maybe) (show:: Int -> String))
   it "should be homomorphic for Maybe" $
+    property (applyHomo (Proxy :: Proxy Maybe) (show:: Int -> String))
+  it "should be homomorphic for Lists" $
     property (applyHomo (Proxy :: Proxy []) (show:: Int -> String))

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -11,6 +11,7 @@ spec :: Spec
 spec = do
   spec_applyMap
   spec_applyId
+  spec_applyLifted
 
 spec_applyMap :: Spec
 spec_applyMap =
@@ -33,3 +34,14 @@ spec_applyId =
     it "should conserve id for Maybe " $
       property (applyId::Maybe Int -> Bool)
 
+spec_applyLifted :: Spec
+spec_applyLifted =
+  describe "lifted function" $ do
+    it "should be applied to list" $
+      property (let ps :: [Int -> String]
+                    ps = pure show
+                 in applyLifted ps)
+    it "should be applied to Maybe" $
+      property (let ps :: Maybe (Int -> String)
+                    ps = pure show
+                 in applyLifted ps)

--- a/test/Algebra/ApplicativeSpec.hs
+++ b/test/Algebra/ApplicativeSpec.hs
@@ -12,6 +12,7 @@ spec = do
   spec_applyMap
   spec_applyId
   spec_applyLifted
+  spec_applyComp
 
 spec_applyMap :: Spec
 spec_applyMap =
@@ -45,3 +46,19 @@ spec_applyLifted =
       property (let ps :: Maybe (Int -> String)
                     ps = pure show
                  in applyLifted ps)
+
+spec_applyComp :: Spec
+spec_applyComp =
+  describe "apply composition" $ do
+    it "should be lifted for lists" $
+      property (let f :: [Double -> Double]
+                    f = [sqrt]
+                    g :: [Double -> String]
+                    g = [show]
+                 in applyComp g f)
+    it "should be lifted for Maybe" $
+      property (let f :: Maybe (Double -> Double)
+                    f = Just sqrt
+                    g :: Maybe (Double -> String)
+                    g = Just show
+                 in applyComp g f)


### PR DESCRIPTION
We provide here the definition for `Applicative` and  its laws `ApplicativeLaws`.
The `applyHomo` law tests the applicative law for homomorphism

```$haskell
pure g |*| pure x == pure (g x)
```

By its nature the function definition for the law would not be provide enough element in the head of the function signature, to satisfy the constraints in the context of the signature ( Ross Paterson conditions ):

```$haskell
(Eq (f b), Applicative f) => (a -> b) -> a -> Bool
```
We have to somehow reify the higher kind `f`, in the head part of the function signature. This is possible by using  the support to kind polymorphism provided by GHC through the usage of `Data.Proxy`
The solution is more elegant than using workarounds forcing the compiler to be more lose in activating the undecidable language PRAGMA for example.

We solve the problem in the Applicative module, by activating the `ScopedTypeVariables` extension in order to guide the compiler when resolving the implementation of the (higher kind) polymorphic method:

```$haskell
homomorphism :: forall a b proxy f.(Eq (f b), Applicative f) => proxy f -> (a -> b) -> a -> Bool
homomorphism _ g x = (pure (g x) :: f b) == (pure g |*| (pure x :: f a))
```

The invocation of the `property` function test wise, clearly denotes the intention of using a specific  higher kind vs another

```
property (applyHomo (Proxy :: Proxy Maybe) (show:: Int -> String))
```

That approach literally passes the reified instance of the expected type as a first parameter. We think that approach to be close enough to the scala denotation

```$scala
def foo[F[_] : Applicative] = ...
//foo[Maybe]
```